### PR TITLE
[blog] Add props to control Ricos styling

### DIFF
--- a/examples/astro-blog-demo/src/react-pages/blog/[slug].tsx
+++ b/examples/astro-blog-demo/src/react-pages/blog/[slug].tsx
@@ -16,6 +16,7 @@ import {
 } from '@wix/headless-blog/services';
 import { KitchensinkLayout } from '../../layouts/KitchensinkLayout';
 import '../../styles/theme-blog.css';
+import '@wix/headless-blog/react/styles.css';
 import { BlogPost, BlogFeed } from '@wix/headless-blog/react';
 
 interface BlogPostPageProps {

--- a/packages/headless-components/blog/package.json
+++ b/packages/headless-components/blog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wix/headless-blog",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "type": "module",
   "scripts": {
     "prebuild": "cd ../utils && yarn build && cd ../components && yarn build && cd ../media && yarn build",

--- a/packages/headless-components/blog/package.json
+++ b/packages/headless-components/blog/package.json
@@ -4,9 +4,10 @@
   "type": "module",
   "scripts": {
     "prebuild": "cd ../utils && yarn build && cd ../components && yarn build && cd ../media && yarn build",
-    "build": "npm run build:esm && npm run build:cjs",
+    "build": "npm run build:esm && npm run build:cjs && npm run copy-assets",
     "build:esm": "tsc -p tsconfig.json",
     "build:cjs": "tsc -p tsconfig.cjs.json",
+    "copy-assets": "cp src/react/styles.css dist/react/styles.css",
     "test": "vitest",
     "lint:fix": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,md}\"",
     "lint:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,json,md}\""
@@ -25,6 +26,7 @@
       "import": "./dist/react/index.js",
       "require": "./cjs/dist/react/index.js"
     },
+    "./react/styles.css": "./dist/react/styles.css",
     "./services": {
       "types": "./dist/services/index.d.ts",
       "import": "./dist/services/index.js",

--- a/packages/headless-components/blog/src/react/BlogCategories.tsx
+++ b/packages/headless-components/blog/src/react/BlogCategories.tsx
@@ -16,7 +16,7 @@ const CategoriesContext = React.createContext<CategoriesContextValue | null>(
   null,
 );
 
-export function useCategoriesContext(): CategoriesContextValue {
+function useCategoriesContext(): CategoriesContextValue {
   const context = React.useContext(CategoriesContext);
   if (!context) {
     throw new Error(

--- a/packages/headless-components/blog/src/react/BlogPost.tsx
+++ b/packages/headless-components/blog/src/react/BlogPost.tsx
@@ -3,8 +3,11 @@ import { AsChildSlot, AsChildChildren } from '@wix/headless-utils/react';
 import * as CoreBlogPost from './core/BlogPost.js';
 import type { PostWithResolvedFields } from '../services/blog-feed-service.js';
 import { posts, tags } from '@wix/blog';
-import { quickStartViewerPlugins, RicosViewer } from '@wix/ricos';
-import '@wix/ricos/css/all-plugins-viewer.css';
+import {
+  quickStartViewerPlugins,
+  RicosViewer,
+  type RicosCustomStyles,
+} from '@wix/ricos';
 import { createAuthorName } from './helpers.js';
 
 interface PostContextValue {
@@ -52,6 +55,12 @@ export interface BlogPostRootProps {
  * Root container for blog post that provides post context to all child components.
  * Supports both service-driven and prop-driven post data.
  * Follows Container Level pattern from architecture rules.
+ *
+ * **Important:** This package requires manual CSS import for proper styling:
+ * ```tsx
+ * import '@wix/headless-blog/react/styles.css';
+ * ```
+ * The CSS is required for proper rendering of BlogPost.Content and other styled components.
  *
  * @component
  * @example
@@ -208,10 +217,17 @@ export interface ContentProps {
   asChild?: boolean;
   className?: string;
   children?: AsChildChildren<{ ricosViewerContent: any }> | React.ReactNode;
+  customStyles?: RicosCustomStyles;
 }
 
 /**
  * Displays the blog post rich content using Wix Ricos viewer.
+ *
+ * **Note:** Requires CSS import for proper content styling:
+ * ```tsx
+ * import '@wix/headless-blog/react/styles.css';
+ * ```
+ * Without this import, the rich content may not render with proper typography and layout.
  *
  * @component
  * @example
@@ -221,6 +237,17 @@ export interface ContentProps {
  *
  * // Custom styling
  * <BlogPost.Content className="prose max-w-[60ch] mx-auto" />
+ *
+ * // Custom Ricos styles using CSS custom properties
+ * <BlogPost.Content
+ *   customStyles={{
+ *     p: {
+ *       fontSize: 'var(--text-lg)',
+ *       lineHeight: 'var(--leading-relaxed)',
+ *       color: 'var(--color-content-primary)',
+ *     },
+ *   }}
+ * />
  *
  * // Custom rendering with asChild
  * <BlogPost.Content asChild>
@@ -234,7 +261,7 @@ export interface ContentProps {
  */
 export const Content = React.forwardRef<HTMLElement, ContentProps>(
   (props, ref) => {
-    const { asChild, children, className } = props;
+    const { asChild, children, className, customStyles } = props;
 
     return (
       <CoreBlogPost.RichContent>
@@ -258,6 +285,9 @@ export const Content = React.forwardRef<HTMLElement, ContentProps>(
                 <RicosViewer
                   content={ricosViewerContent}
                   plugins={quickStartViewerPlugins()}
+                  theme={{
+                    customStyles,
+                  }}
                 />
               </div>
             </AsChildSlot>

--- a/packages/headless-components/blog/src/react/index.tsx
+++ b/packages/headless-components/blog/src/react/index.tsx
@@ -8,5 +8,8 @@ export * as BlogFeed from './BlogFeed.js';
 export * as BlogCategories from './BlogCategories.js';
 export * as BlogPost from './BlogPost.js';
 
+// CSS exports - consumers must import this alongside components
+// import '@wix/headless-blog/react/styles.css';
+
 // Utility exports
 export { createCustomCategory } from './BlogCategories.js';

--- a/packages/headless-components/blog/src/react/styles.css
+++ b/packages/headless-components/blog/src/react/styles.css
@@ -1,0 +1,3 @@
+/* Re-export ricos CSS for blog components */
+/* Consumers should import this alongside the components */
+@import '@wix/ricos/css/all-plugins-viewer.css';


### PR DESCRIPTION
- Introduced styles.css to re-export Ricos CSS for consumers.
- Refactored BlogCategories context usage to encapsulate within the file.
- Updated BlogPost component to support custom styles for Ricos viewer.