### PR TITLE
[blog] Update PostRepeater context to use posts length

### DIFF
--- a/packages/headless-components/blog/package.json
+++ b/packages/headless-components/blog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wix/headless-blog",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "type": "module",
   "scripts": {
     "prebuild": "cd ../utils && yarn build && cd ../components && yarn build && cd ../media && yarn build",

--- a/packages/headless-components/blog/src/react/BlogFeed.tsx
+++ b/packages/headless-components/blog/src/react/BlogFeed.tsx
@@ -394,7 +394,7 @@ export interface PostRepeaterProps {
 export const PostRepeater = React.forwardRef<HTMLElement, PostRepeaterProps>(
   (props, _ref) => {
     const { children } = props;
-    const { hasPosts, posts, totalPosts } = usePostsContext();
+    const { hasPosts, posts } = usePostsContext();
 
     if (!hasPosts) return null;
 
@@ -404,7 +404,7 @@ export const PostRepeater = React.forwardRef<HTMLElement, PostRepeaterProps>(
           const contextValue: FeedPostRepeaterContextValue = {
             post,
             index,
-            amount: totalPosts,
+            amount: posts.length,
           };
 
           return (


### PR DESCRIPTION
- Removed totalPosts from posts repeater context value (current Wix SDK returns length of 0 always)