### PR TITLE
Product list safer types

### DIFF
--- a/packages/headless-components/components/package.json
+++ b/packages/headless-components/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wix/headless-components",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "type": "module",
   "scripts": {
     "build": "npm run build:esm && npm run build:cjs",

--- a/packages/headless-components/components/src/react/generic-list.tsx
+++ b/packages/headless-components/components/src/react/generic-list.tsx
@@ -60,6 +60,12 @@ export interface GenericListItemsProps {
   className?: string;
 }
 
+export interface GenericListLoadMoreRenderProps {
+  isLoading: boolean;
+  hasMore: boolean;
+  onLoadMore: () => void;
+}
+
 /**
  * Props for the GenericList LoadMore component
  */
@@ -69,7 +75,12 @@ export interface GenericListLoadMoreProps {
   /** Loading state content */
   loadingState?: React.ReactNode;
   /** Children for custom rendering - optional but either children or label must be provided */
-  children?: React.ReactNode;
+  children?:
+    | React.ReactNode
+    | ((
+        props: GenericListLoadMoreRenderProps,
+        ref: React.Ref<HTMLElement>,
+      ) => React.ReactNode);
   /** CSS classes */
   className?: string;
 }

--- a/packages/headless-components/components/src/react/generic-list.tsx
+++ b/packages/headless-components/components/src/react/generic-list.tsx
@@ -74,6 +74,10 @@ export interface GenericListLoadMoreProps {
   className?: string;
 }
 
+export interface GenericListTotalsRenderProps {
+  displayedItems: number;
+}
+
 /**
  * Props for the GenericList Totals component
  */
@@ -82,7 +86,7 @@ export interface GenericListTotalsProps {
   children?:
     | React.ReactNode
     | ((
-        props: { totalItems: number; displayedItems: number },
+        props: GenericListTotalsRenderProps,
         ref: React.Ref<HTMLElement>,
       ) => React.ReactNode);
   /** CSS classes */

--- a/packages/headless-components/components/src/react/index.tsx
+++ b/packages/headless-components/components/src/react/index.tsx
@@ -49,4 +49,5 @@ export type {
   GenericListItemsProps,
   GenericListLoadMoreProps,
   GenericListTotalsProps,
+  GenericListTotalsRenderProps,
 } from './generic-list.js';

--- a/packages/headless-components/components/src/react/index.tsx
+++ b/packages/headless-components/components/src/react/index.tsx
@@ -48,6 +48,7 @@ export type {
   GenericListRootProps,
   GenericListItemsProps,
   GenericListLoadMoreProps,
+  GenericListLoadMoreRenderProps,
   GenericListTotalsProps,
   GenericListTotalsRenderProps,
 } from './generic-list.js';

--- a/packages/headless-components/stores/package.json
+++ b/packages/headless-components/stores/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wix/headless-stores",
-  "version": "0.0.92",
+  "version": "0.0.93",
   "type": "module",
   "scripts": {
     "prebuild": "cd ../media && yarn build && cd ../ecom && yarn build",

--- a/packages/headless-components/stores/src/react/ProductList.tsx
+++ b/packages/headless-components/stores/src/react/ProductList.tsx
@@ -1,6 +1,7 @@
 import type { V3Product } from '@wix/auto_sdk_stores_products-v-3';
 import {
   Sort as SortPrimitive,
+  GenericListTotalsRenderProps,
   GenericList,
 } from '@wix/headless-components/react';
 import { useService } from '@wix/services-manager-react';
@@ -337,9 +338,7 @@ export interface TotalsDisplayedProps {
   /** Whether to render as a child component */
   asChild?: boolean;
   /** Custom render function when using asChild */
-  children?: AsChildChildren<{
-    displayedItems: number;
-  }>;
+  children?: AsChildChildren<GenericListTotalsRenderProps>;
   /** CSS classes to apply to the default element */
   className?: string;
 }
@@ -357,7 +356,7 @@ export interface TotalsDisplayedProps {
  * </ProductList.TotalsDisplayed>
  * // or with render function
  * <ProductList.TotalsDisplayed asChild>
- *   {({ displayedProducts }, ref) => <strong ref={ref}>{displayedProducts}</strong>}
+ *   {({ displayedItems }, ref) => <strong ref={ref}>{displayedItems}</strong>}
  * </ProductList.TotalsDisplayed>
  * ```
  */

--- a/packages/headless-components/stores/src/react/ProductList.tsx
+++ b/packages/headless-components/stores/src/react/ProductList.tsx
@@ -2,6 +2,7 @@ import type { V3Product } from '@wix/auto_sdk_stores_products-v-3';
 import {
   Sort as SortPrimitive,
   GenericListTotalsRenderProps,
+  GenericListLoadMoreRenderProps,
   GenericList,
 } from '@wix/headless-components/react';
 import { useService } from '@wix/services-manager-react';
@@ -275,11 +276,7 @@ export interface LoadMoreTriggerProps {
     | React.ReactNode
     | React.ForwardRefRenderFunction<
         HTMLButtonElement,
-        {
-          isLoading: boolean;
-          hasMoreProducts: boolean;
-          loadMore: () => void;
-        }
+        GenericListLoadMoreRenderProps
       >;
   /**
    * Whether to render as a child component.


### PR DESCRIPTION
To avoid breaking changes, we aim to reuse the generic list types and reduce the risk of incorrect prop usage. This PR introduces a new renderProps type and reuses it in the ProductList.