### PR TITLE
headless-ecom: adds data-component-tags

### DIFF
--- a/packages/headless-components/ecom/package.json
+++ b/packages/headless-components/ecom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wix/headless-ecom",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "type": "module",
   "scripts": {
     "build": "npm run build:esm && npm run build:cjs",

--- a/packages/headless-components/ecom/src/data-component-tags.ts
+++ b/packages/headless-components/ecom/src/data-component-tags.ts
@@ -1,0 +1,7 @@
+export enum DataComponentTags {
+  cartRoot = `ecom.cart-root`,
+  cartCouponRoot = `ecom.cart-coupon-root`,
+  commerceRoot = `ecom.commerce-root`,
+  lineItemRoot = `ecom.line-item-root`,
+  selectedOptionRoot = `ecom.selected-option-root`,
+}

--- a/packages/headless-components/ecom/src/react/Cart.test.tsx
+++ b/packages/headless-components/ecom/src/react/Cart.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import '@testing-library/jest-dom';
+import * as Cart from './Cart';
+
+describe('Cart', () => {
+  describe('Root', () => {
+    it('renders data-component-tag attribute on first DOM element', () => {
+      render(
+        <Cart.Root>
+          <div>Content</div>
+        </Cart.Root>,
+      );
+
+      const rootElement = screen.getByTestId('cart-root');
+      expect(rootElement).toHaveAttribute(
+        'data-component-tag',
+        'ecom.cart-root',
+      );
+    });
+  });
+});

--- a/packages/headless-components/ecom/src/react/Cart.tsx
+++ b/packages/headless-components/ecom/src/react/Cart.tsx
@@ -62,6 +62,7 @@ import type { LineItem } from '../services/common-types.js';
 import { AsChildSlot, AsChildChildren } from '@wix/headless-utils/react';
 import * as LineItemComponent from './LineItem.js';
 import * as CouponComponents from './CartCoupon.js';
+import { DataComponentTags } from '../data-component-tags.js';
 
 // Components that render actual DOM elements get test IDs on their rendered elements
 // Components that only provide context/logic don't introduce new DOM elements
@@ -115,8 +116,17 @@ export interface RootProps {
  * ```
  */
 export const Root = ({ children }: RootProps) => {
-  return <>{children}</>;
+  return (
+    <AsChildSlot
+      data-component-tag={DataComponentTags.cartRoot}
+      data-testid={TestIds.cartRoot}
+    >
+      {children}
+    </AsChildSlot>
+  );
 };
+
+Root.displayName = 'Cart.Root';
 
 /**
  * Props for EmptyState component with asChild support

--- a/packages/headless-components/ecom/src/react/CartCoupon.test.tsx
+++ b/packages/headless-components/ecom/src/react/CartCoupon.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import '@testing-library/jest-dom';
+import * as CartCoupon from './CartCoupon';
+
+describe('CartCoupon', () => {
+  describe('Root', () => {
+    it('renders data-component-tag attribute on first DOM element', () => {
+      const { container } = render(
+        <CartCoupon.Root>
+          <div>Content</div>
+        </CartCoupon.Root>,
+      );
+
+      const rootElement = container.querySelector(
+        '[data-component-tag="ecom.cart-coupon-root"]',
+      )!;
+      expect(rootElement).toHaveAttribute(
+        'data-component-tag',
+        'ecom.cart-coupon-root',
+      );
+    });
+  });
+});

--- a/packages/headless-components/ecom/src/react/CartCoupon.tsx
+++ b/packages/headless-components/ecom/src/react/CartCoupon.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import { Slot } from '@radix-ui/react-slot';
+import { DataComponentTags } from '../data-component-tags.js';
 
 import { Coupon as CoreCoupon } from './core/CurrentCart.js';
 
@@ -79,11 +80,15 @@ export const Root = React.forwardRef<HTMLDivElement, CouponRootProps>(
 
     return (
       <CouponContext.Provider value={contextValue}>
-        <div ref={ref}>{children}</div>
+        <div ref={ref} data-component-tag={DataComponentTags.cartCouponRoot}>
+          {children}
+        </div>
       </CouponContext.Provider>
     );
   },
 );
+
+Root.displayName = 'CartCoupon.Root';
 
 /**
  * Props for Coupon.Input component

--- a/packages/headless-components/ecom/src/react/Commerce.test.tsx
+++ b/packages/headless-components/ecom/src/react/Commerce.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom';
+import * as Commerce from './Commerce';
+
+describe('Commerce', () => {
+  describe('Root', () => {
+    it('renders data-component-tag attribute on first DOM element', () => {
+      const { container } = render(
+        <Commerce.Root>
+          <div>Content</div>
+        </Commerce.Root>,
+      );
+
+      // AsChildSlot should apply the data-component-tag to the first DOM element
+      const rootElement = container.firstElementChild;
+      expect(rootElement).toHaveAttribute(
+        'data-component-tag',
+        'ecom.commerce-root',
+      );
+    });
+  });
+});

--- a/packages/headless-components/ecom/src/react/Commerce.tsx
+++ b/packages/headless-components/ecom/src/react/Commerce.tsx
@@ -74,6 +74,7 @@ import {
   Root as CoreCheckoutRoot,
 } from './core/Checkout.js';
 import React from 'react';
+import { DataComponentTags } from '../data-component-tags.js';
 import { type LineItem } from '../services/checkout-service.js';
 
 /**
@@ -119,10 +120,14 @@ export interface RootProps {
 export const Root = ({ checkoutServiceConfig, children }: RootProps) => {
   return (
     <CoreCheckoutRoot checkoutServiceConfig={checkoutServiceConfig}>
-      {children}
+      <AsChildSlot data-component-tag={DataComponentTags.commerceRoot}>
+        {children}
+      </AsChildSlot>
     </CoreCheckoutRoot>
   );
 };
+
+Root.displayName = 'Commerce.Root';
 
 /**
  * Props for the ActionCheckout component.

--- a/packages/headless-components/ecom/src/react/CurrentCart.tsx
+++ b/packages/headless-components/ecom/src/react/CurrentCart.tsx
@@ -18,6 +18,7 @@ export interface RootProps {
 
 export const Root = ({ children, currentCartServiceConfig }: RootProps) => {
   return (
+    // we don't supply data-component-tag here because it's already provided by the CartRoot component
     <CoreRoot
       currentCartServiceConfig={currentCartServiceConfig}
       data-testid={TestIds.currentCartRoot}
@@ -26,3 +27,5 @@ export const Root = ({ children, currentCartServiceConfig }: RootProps) => {
     </CoreRoot>
   );
 };
+
+Root.displayName = 'CurrentCart.Root';

--- a/packages/headless-components/ecom/src/react/LineItem.test.tsx
+++ b/packages/headless-components/ecom/src/react/LineItem.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import '@testing-library/jest-dom';
+import * as LineItem from './LineItem';
+
+const mockLineItem = {
+  id: 'test-line-item-id',
+  productName: 'Test Product',
+  quantity: 1,
+  price: { amount: '29.99', currency: 'USD' },
+};
+
+describe('LineItem', () => {
+  describe('Root', () => {
+    it('renders data-component-tag attribute on first DOM element', () => {
+      const { container } = render(
+        <LineItem.Root item={mockLineItem}>
+          <div>Product: {mockLineItem.productName}</div>
+        </LineItem.Root>,
+      );
+
+      const rootElement = container.firstElementChild;
+      expect(rootElement).toHaveAttribute(
+        'data-component-tag',
+        'ecom.line-item-root',
+      );
+    });
+
+    it('renders data-component-tag attribute on custom element when asChild=true', () => {
+      const { container } = render(
+        <LineItem.Root item={mockLineItem} asChild={true}>
+          <div>Product: {mockLineItem.productName}</div>
+        </LineItem.Root>,
+      );
+
+      const rootElement = container.firstElementChild;
+      expect(rootElement).toHaveAttribute(
+        'data-component-tag',
+        'ecom.line-item-root',
+      );
+      expect(rootElement).toHaveTextContent('Product: Test Product');
+    });
+  });
+});

--- a/packages/headless-components/ecom/src/react/LineItem.tsx
+++ b/packages/headless-components/ecom/src/react/LineItem.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { type LineItem } from '../services/common-types.js';
 import { AsChildSlot, AsChildChildren } from '@wix/headless-utils/react';
+import { DataComponentTags } from '../data-component-tags.js';
 import { WixMediaImage } from '@wix/headless-media/react';
 import * as SelectedOption from './SelectedOption.js';
 import { Item as CoreItem } from './core/CurrentCart.js';
@@ -58,18 +59,19 @@ export const Root = React.forwardRef<HTMLElement, LineItemRootProps>(
     };
 
     return (
-      <AsChildSlot
-        ref={ref}
-        asChild={asChild}
-        data-testid={TestIds.lineItemRoot}
-        customElement={children}
-        customElementProps={{ item }}
-        {...otherProps}
-      >
-        <LineItemContext.Provider value={contextValue}>
+      <LineItemContext.Provider value={contextValue}>
+        <AsChildSlot
+          ref={ref}
+          asChild={asChild}
+          data-testid={TestIds.lineItemRoot}
+          customElement={children}
+          customElementProps={{ item }}
+          data-component-tag={DataComponentTags.lineItemRoot}
+          {...otherProps}
+        >
           <div>{children}</div>
-        </LineItemContext.Provider>
-      </AsChildSlot>
+        </AsChildSlot>
+      </LineItemContext.Provider>
     );
   },
 );

--- a/packages/headless-components/ecom/src/react/LineItem.tsx
+++ b/packages/headless-components/ecom/src/react/LineItem.tsx
@@ -59,19 +59,19 @@ export const Root = React.forwardRef<HTMLElement, LineItemRootProps>(
     };
 
     return (
-      <LineItemContext.Provider value={contextValue}>
-        <AsChildSlot
-          ref={ref}
-          asChild={asChild}
-          data-testid={TestIds.lineItemRoot}
-          customElement={children}
-          customElementProps={{ item }}
-          data-component-tag={DataComponentTags.lineItemRoot}
-          {...otherProps}
-        >
-          <div>{children}</div>
-        </AsChildSlot>
-      </LineItemContext.Provider>
+      <AsChildSlot
+        ref={ref}
+        asChild={asChild}
+        data-testid={TestIds.lineItemRoot}
+        data-component-tag={DataComponentTags.lineItemRoot}
+        customElement={children}
+        customElementProps={{ item }}
+        {...otherProps}
+      >
+        <LineItemContext.Provider value={contextValue}>
+          <div data-component-tag={DataComponentTags.lineItemRoot}>{children}</div>
+        </LineItemContext.Provider>
+      </AsChildSlot>
     );
   },
 );

--- a/packages/headless-components/ecom/src/react/LineItem.tsx
+++ b/packages/headless-components/ecom/src/react/LineItem.tsx
@@ -69,7 +69,9 @@ export const Root = React.forwardRef<HTMLElement, LineItemRootProps>(
         {...otherProps}
       >
         <LineItemContext.Provider value={contextValue}>
-          <div data-component-tag={DataComponentTags.lineItemRoot}>{children}</div>
+          <div data-component-tag={DataComponentTags.lineItemRoot}>
+            {children}
+          </div>
         </LineItemContext.Provider>
       </AsChildSlot>
     );

--- a/packages/headless-components/ecom/src/react/SelectedOption.test.tsx
+++ b/packages/headless-components/ecom/src/react/SelectedOption.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom';
+import * as SelectedOption from './SelectedOption';
+
+describe('SelectedOption', () => {
+  describe('Root', () => {
+    it('renders data-component-tag attribute on first DOM element', () => {
+      const { container } = render(
+        <SelectedOption.Root
+          option={{
+            name: 'Size',
+            type: 'text',
+            value: 'Large',
+          }}
+        >
+          <div>Content</div>
+        </SelectedOption.Root>,
+      );
+
+      // AsChildSlot should apply the data-component-tag to the first DOM element
+      const rootElement = container.firstElementChild;
+      expect(rootElement).toHaveAttribute(
+        'data-component-tag',
+        'ecom.selected-option-root',
+      );
+    });
+  });
+});

--- a/packages/headless-components/ecom/src/react/SelectedOption.tsx
+++ b/packages/headless-components/ecom/src/react/SelectedOption.tsx
@@ -1,5 +1,6 @@
 import { WixServices, useService } from '@wix/services-manager-react';
 import React from 'react';
+import { DataComponentTags } from '../data-component-tags.js';
 import {
   SelectedOptionServiceDefinition,
   SelectedOptionService,
@@ -32,7 +33,7 @@ export interface SelectedOptionRootProps {
  * </SelectedOption.Root>
  * ```
  */
-export function Root(props: SelectedOptionRootProps): React.ReactNode {
+export const Root = (props: SelectedOptionRootProps): React.ReactNode => {
   const { children, option } = props;
 
   return (
@@ -45,7 +46,9 @@ export function Root(props: SelectedOptionRootProps): React.ReactNode {
         },
       )}
     >
-      {children}
+      <AsChildSlot data-component-tag={DataComponentTags.selectedOptionRoot}>
+        {children}
+      </AsChildSlot>
     </WixServices>
   );
 }

--- a/packages/headless-components/ecom/src/react/SelectedOption.tsx
+++ b/packages/headless-components/ecom/src/react/SelectedOption.tsx
@@ -51,7 +51,7 @@ export const Root = (props: SelectedOptionRootProps): React.ReactNode => {
       </AsChildSlot>
     </WixServices>
   );
-}
+};
 
 Root.displayName = 'SelectedOption.Root';
 


### PR DESCRIPTION
## Add data-component-tag support to ecom components

### Components with data-component-tag:

- **Cart.Root** → `ecom.cart-root`
- **CartCoupon.Root** → `ecom.cart-coupon-root`  
- **Commerce.Root** → `ecom.commerce-root`
- **LineItem.Root** → `ecom.line-item-root`
- **SelectedOption.Root** → `ecom.selected-option-root`

### Changes:
- Added `DataComponentTags` enum
- Updated Root components to inject `data-component-tag` via AsChildSlot
- Added tests for data-component-tag injection in both default and asChild modes

#pr