### PR TITLE
[CMS] - Implemented sort

### DIFF
--- a/packages/headless-components/cms/package.json
+++ b/packages/headless-components/cms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wix/headless-cms",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "type": "module",
   "scripts": {
     "build": "npm run build:esm && npm run build:cjs",

--- a/packages/headless-components/cms/package.json
+++ b/packages/headless-components/cms/package.json
@@ -32,6 +32,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@types/node": "^20.9.0",
     "@vitest/ui": "^3.1.4",
+    "@wix/headless-components": "workspace:*",
     "jsdom": "^26.1.0",
     "prettier": "^3.4.2",
     "typescript": "^5.8.3",

--- a/packages/headless-components/cms/src/react/core/CmsCollectionSort.tsx
+++ b/packages/headless-components/cms/src/react/core/CmsCollectionSort.tsx
@@ -1,0 +1,39 @@
+import type { ServiceAPI } from '@wix/services-definitions';
+import { useService } from '@wix/services-manager-react';
+import { CmsCollectionServiceDefinition } from '../../services/cms-collection-service.js';
+import type { SortValue } from '@wix/headless-components/react';
+
+/**
+ * Props for CmsCollectionSort headless component
+ */
+export interface CmsCollectionSortProps {
+  /** Render prop function that receives sort controls */
+  children: (props: CmsCollectionSortRenderProps) => React.ReactNode;
+}
+
+/**
+ * Render props for CmsCollectionSort component
+ */
+export interface CmsCollectionSortRenderProps {
+  /** Current sort value */
+  currentSort: SortValue;
+  /** Function to update the sort */
+  setSort: (sort: SortValue) => void;
+}
+
+/**
+ * Core headless component for CMS collection sorting
+ */
+export function CmsCollectionSort(props: CmsCollectionSortProps) {
+  const service = useService(CmsCollectionServiceDefinition) as ServiceAPI<
+    typeof CmsCollectionServiceDefinition
+  >;
+
+  const currentSort = service.sortSignal.get();
+  const setSort = service.setSort;
+
+  return props.children({
+    currentSort,
+    setSort,
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7600,6 +7600,7 @@ __metadata:
     "@types/node": "npm:^20.9.0"
     "@vitest/ui": "npm:^3.1.4"
     "@wix/data": "npm:^1.0.0"
+    "@wix/headless-components": "workspace:*"
     "@wix/headless-utils": "workspace:*"
     "@wix/services-definitions": "npm:^0.1.4"
     "@wix/services-manager-react": "npm:^0.1.26"


### PR DESCRIPTION
## Add Sorting Support to CMS Collection

Implements sorting functionality for CMS collections following the CMS Collection Interface specification.

### Changes

#### Service Layer (`cms-collection-service.ts`)
- Added `sortSignal` to track current sort state
- Added `setSort()` method to update sort and reload items
- Added `initialSort` to service configuration
- Updated `loadCollectionItems()` to apply sort using `query.ascending()` / `query.descending()`
- Updated `loadCmsCollectionServiceInitialData()` to accept optional `sort` parameter

#### Components
- **New:** `CmsCollectionSort.tsx` - Headless component providing sort state from service
- **New:** `CmsCollection.Sort` - Styled wrapper around Sort primitive with CMS state management
- **New:** `CmsCollection.SortOption` - Re-export of Sort primitive's Option component
- Updated `CmsCollection.Root` to accept `initialSort` in collection config

#### Features
- ✅ Supports dynamic field names (unknown schemas)
- ✅ Native `<select>` and custom list rendering modes
- ✅ AsChild pattern support for full customization
- ✅ Automatic collection reload on sort change
- ✅ Preserves sort state during pagination
- ✅ Data attributes for testing: `data-sorted-by`, `data-sort-direction`

### Usage Examples

```tsx
// Native select
<CmsCollection.Sort
  as="select"
  sortOptions={[
    { fieldName: 'title', order: 'ASC', label: 'Title (A-Z)' },
    { fieldName: 'created', order: 'DESC', label: 'Newest First' },
  ]}
/>

// Custom buttons
<CmsCollection.Sort as="list">
  <CmsCollection.SortOption fieldName="title" order="ASC" label="Title (A-Z)" />
  <CmsCollection.SortOption fieldName="created" order="DESC" label="Newest" />
</CmsCollection.Sort>
```

### Technical Notes
- Uses platform Sort primitive for consistent behavior across packages
- Sort state is reactive (signal-based) and triggers automatic reloads
- Designed for extensibility (supports SortValue array for future multi-sort)
- Currently applies first sort item only (Wix Data SDK limitation)