### PR TITLE
[blog] Use GenericList for Feed

### DIFF
--- a/examples/astro-blog-demo/src/components/blog/FeedPage.tsx
+++ b/examples/astro-blog-demo/src/components/blog/FeedPage.tsx
@@ -42,7 +42,6 @@ export default function FeedPage({
     <Blog.Feed.Root blogFeedServiceConfig={blogFeedServiceConfig}>
       <SortSelect sortComponent={Blog.Feed.Sort} className="mb-2" />
       <Blog.Feed.PostItems
-        className="grid gap-x-8 gap-y-12 lg:grid-cols-2 xl:grid-cols-3"
         emptyState={
           <EmptyState
             title="No Posts Found"
@@ -50,37 +49,38 @@ export default function FeedPage({
           />
         }
       >
-        <Blog.Feed.PostItemRepeater offset={0} limit={1}>
-          <BlogFeedCardSideBySide
-            className="col-span-full"
-            uiLocale={uiLocale}
-            postPageBaseUrl={postPageBaseUrl}
-            categoryPageBaseUrl={categoryPageBaseUrl}
-            readMoreText="Read more"
-          />
-        </Blog.Feed.PostItemRepeater>
-        <Blog.Feed.PostItemRepeater offset={1}>
-          <BlogFeedCardEditorial
-            uiLocale={uiLocale}
-            postPageBaseUrl={postPageBaseUrl}
-            categoryPageBaseUrl={categoryPageBaseUrl}
-            readMoreText="Read more"
-          />
-        </Blog.Feed.PostItemRepeater>
+        <div className="grid gap-x-8 gap-y-12 lg:grid-cols-2 xl:grid-cols-3">
+          <Blog.Feed.PostItemRepeater offset={0} limit={1}>
+            <BlogFeedCardSideBySide
+              className="col-span-full"
+              uiLocale={uiLocale}
+              postPageBaseUrl={postPageBaseUrl}
+              categoryPageBaseUrl={categoryPageBaseUrl}
+              readMoreText="Read more"
+            />
+          </Blog.Feed.PostItemRepeater>
+          <Blog.Feed.PostItemRepeater offset={1}>
+            <BlogFeedCardEditorial
+              uiLocale={uiLocale}
+              postPageBaseUrl={postPageBaseUrl}
+              categoryPageBaseUrl={categoryPageBaseUrl}
+              readMoreText="Read more"
+            />
+          </Blog.Feed.PostItemRepeater>
 
-        {/* Load More Button */}
-        <div className="col-span-full mt-12 text-center">
-          <Blog.Feed.LoadMore
-            asChild
-            loadingState={
-              <>
-                <Loader2Icon className="animate-spin" />
-                Loading...
-              </>
-            }
-          >
-            <Button variant="outline">Load More Posts</Button>
-          </Blog.Feed.LoadMore>
+          {/* Load More Button */}
+          <div className="col-span-full mt-12 text-center">
+            <Blog.Feed.LoadMore
+              loadingState={
+                <>
+                  <Loader2Icon className="animate-spin" />
+                  Loading...
+                </>
+              }
+            >
+              <Button variant="outline">Load More Posts</Button>
+            </Blog.Feed.LoadMore>
+          </div>
         </div>
       </Blog.Feed.PostItems>
     </Blog.Feed.Root>

--- a/packages/headless-components/blog/package.json
+++ b/packages/headless-components/blog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wix/headless-blog",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "type": "module",
   "scripts": {
     "prebuild": "cd ../utils && yarn build && cd ../components && yarn build && cd ../media && yarn build",

--- a/packages/headless-components/blog/src/react/Feed.tsx
+++ b/packages/headless-components/blog/src/react/Feed.tsx
@@ -1,4 +1,9 @@
-import { Sort as SortPrimitive } from '@wix/headless-components/react';
+import {
+  Sort as SortPrimitive,
+  GenericList,
+  type ListVariant,
+  type GenericListRepeaterRenderProps,
+} from '@wix/headless-components/react';
 import { AsChildChildren, AsChildSlot } from '@wix/headless-utils/react';
 import { createServicesMap } from '@wix/services-manager';
 import { WixServices } from '@wix/services-manager-react';
@@ -50,6 +55,7 @@ export interface BlogFeedRootProps {
   children: AsChildChildren<{ hasPosts: boolean }> | React.ReactNode;
   blogFeedServiceConfig: BlogFeedServiceConfig;
   fallbackImageUrl?: string;
+  variant?: ListVariant;
 }
 
 /**
@@ -77,7 +83,7 @@ export interface BlogFeedRootProps {
  * ```
  */
 export const Root = React.forwardRef<HTMLElement, BlogFeedRootProps>((props, ref) => {
-  const { asChild, children, className, blogFeedServiceConfig, fallbackImageUrl } = props;
+  const { asChild, children, className, blogFeedServiceConfig, fallbackImageUrl, variant } = props;
 
   return (
     <WixServices
@@ -88,7 +94,7 @@ export const Root = React.forwardRef<HTMLElement, BlogFeedRootProps>((props, ref
       )}
     >
       <CoreFeed.Posts>
-        {({ posts, hasPosts, totalPosts, isLoading }) => {
+        {({ posts, hasPosts, totalPosts, isLoading, hasNextPage, loadNextPage }) => {
           const contextValue: PostsContextValue = {
             hasPosts,
             posts,
@@ -96,6 +102,8 @@ export const Root = React.forwardRef<HTMLElement, BlogFeedRootProps>((props, ref
             isLoading,
             fallbackImageUrl,
           };
+
+          const items = posts.map((post) => ({ ...post, id: post._id }));
 
           const attributes = {
             'data-component-tag': HTML_CODE_TAG,
@@ -106,16 +114,24 @@ export const Root = React.forwardRef<HTMLElement, BlogFeedRootProps>((props, ref
 
           return (
             <PostsContext.Provider value={contextValue}>
-              <AsChildSlot
-                ref={ref}
-                asChild={asChild}
-                className={className}
-                {...attributes}
-                customElement={children}
-                customElementProps={{ hasPosts }}
+              <GenericList.Root
+                items={items}
+                loadMore={loadNextPage}
+                hasMore={hasNextPage}
+                isLoading={isLoading}
+                variant={variant}
               >
-                <div>{isValidChildren(children) ? children : null}</div>
-              </AsChildSlot>
+                <AsChildSlot
+                  ref={ref}
+                  asChild={asChild}
+                  className={className}
+                  {...attributes}
+                  customElement={children}
+                  customElementProps={{ hasPosts }}
+                >
+                  <div>{isValidChildren(children) ? children : null}</div>
+                </AsChildSlot>
+              </GenericList.Root>
             </PostsContext.Provider>
           );
         }}
@@ -149,25 +165,23 @@ export interface PostItemsProps {
  */
 export const PostItems = React.forwardRef<HTMLElement, PostItemsProps>((props, ref) => {
   const { children, emptyState, className } = props;
-  const { hasPosts, isLoading } = usePostsContext();
-
-  if (!hasPosts) {
-    return emptyState || null;
-  }
-
-  const attributes = {
-    'data-testid': TestIds.blogFeedPosts,
-    'data-loading': isLoading,
-  };
 
   return (
-    <div {...attributes} ref={ref as React.Ref<HTMLDivElement>} className={className}>
+    <GenericList.Items
+      ref={ref}
+      emptyState={emptyState}
+      className={className}
+      data-testid={TestIds.blogFeedPosts}
+    >
       {children}
-    </div>
+    </GenericList.Items>
   );
 });
 
 PostItems.displayName = 'Blog.Feed.PostItems';
+
+export type PostRepeaterRenderProps =
+  GenericListRepeaterRenderProps<PostWithResolvedFields>;
 
 export interface SortProps {
   /**
@@ -288,45 +302,106 @@ export const Sort = React.forwardRef<HTMLElement, SortProps>(
 Sort.displayName = 'Blog.Feed.Sort';
 
 export interface PostItemRepeaterProps {
-  children: React.ReactNode;
+  children:
+    | React.ReactNode
+    | ((props: PostRepeaterRenderProps, ref: React.Ref<HTMLElement>) => React.ReactNode);
   offset?: number;
   limit?: number;
+  asChild?: boolean;
 }
 
 /**
  * Repeater component that creates individual post contexts for each post.
- * Follows Repeater Level pattern from architecture rules.
- * Note: Repeater components do NOT support asChild as per architecture rules.
+ * Follows Repeater Level pattern from architecture rules and uses GenericList.Repeater for consistency.
+ * Supports asChild pattern for advanced layout components.
  *
  * @component
  * @example
  * ```tsx
+ * // Standard usage
  * <Blog.Feed.PostItemRepeater>
  *   <Blog.Post.Title />
  *   <Blog.Post.Excerpt />
  *   <Blog.Post.PublishDate />
  * </Blog.Feed.PostItemRepeater>
+ *
+ * // With offset/limit
+ * <Blog.Feed.PostItemRepeater offset={0} limit={10}>
+ *   <Blog.Post.Title />
+ * </Blog.Feed.PostItemRepeater>
+ *
+ * // AsChild usage with custom wrapper
+ * <Blog.Feed.PostItemRepeater asChild>
+ *   {({ items, variant, itemWrapper }) => (
+ *     <CustomWrapper
+ *       items={items}
+ *       variant={variant}
+ *       itemRenderer={(item, index) =>
+ *         itemWrapper({ item, index, children: <>
+ *           <Blog.Post.Title />
+ *           <Blog.Post.Excerpt />
+ *         </> })
+ *       }
+ *     />
+ *   )}
+ * </Blog.Feed.PostItemRepeater>
  * ```
  */
 export const PostItemRepeater = React.forwardRef<HTMLElement, PostItemRepeaterProps>(
-  (props, _ref) => {
-    const { children, offset = 0, limit = Infinity } = props;
-    const { hasPosts, posts, fallbackImageUrl } = usePostsContext();
+  (props, ref) => {
+    const { children, offset = 0, limit = Infinity, asChild } = props;
+    const { fallbackImageUrl } = usePostsContext();
 
-    if (!hasPosts) return null;
+    const itemWrapper: GenericList.GenericListRepeaterProps<PostWithResolvedFields>['itemWrapper'] = ({
+      item: post,
+      children,
+    }) => (
+      <Post.Root
+        key={post._id}
+        post={post}
+        asChild
+        fallbackImageUrl={fallbackImageUrl}
+      >
+        {children}
+      </Post.Root>
+    );
 
-    const postsSlice = posts.slice(offset, offset + limit);
 
+    // If offset/limit are used, use asChild pattern to access items and slice them
+    if (offset !== 0 || limit !== Infinity) {
+      return (
+        <GenericList.Repeater<PostWithResolvedFields>
+          ref={ref}
+          asChild={true}
+          itemWrapper={itemWrapper}
+        >
+          {({ items, itemWrapper: wrapper }) => {
+            const postsSlice = items.slice(offset, offset + limit);
+            return (
+              <>
+                {postsSlice.map((post, index) =>
+                  wrapper({
+                    item: post,
+                    index,
+                    children: children as React.ReactNode,
+                  }),
+                )}
+              </>
+            );
+          }}
+        </GenericList.Repeater>
+      );
+    }
+
+    // Otherwise use GenericList.Repeater normally
     return (
-      <>
-        {postsSlice.map((post) => {
-          return (
-            <Post.Root key={post._id} post={post} asChild fallbackImageUrl={fallbackImageUrl}>
-              {children}
-            </Post.Root>
-          );
-        })}
-      </>
+      <GenericList.Repeater<PostWithResolvedFields>
+        ref={ref}
+        asChild={asChild}
+        itemWrapper={itemWrapper}
+      >
+        {children}
+      </GenericList.Repeater>
     );
   },
 );
@@ -334,15 +409,9 @@ export const PostItemRepeater = React.forwardRef<HTMLElement, PostItemRepeaterPr
 PostItemRepeater.displayName = 'Blog.Feed.PostItemRepeater';
 
 export interface LoadMoreProps {
-  asChild?: boolean;
   className?: string;
   loadingState?: React.ReactNode;
-  children?:
-    | AsChildChildren<{
-        isLoading: boolean;
-        loadNextPage: () => Promise<void>;
-      }>
-    | React.ReactNode;
+  children?: React.ReactNode;
 }
 
 /**
@@ -351,53 +420,26 @@ export interface LoadMoreProps {
  * @component
  * @example
  * ```tsx
- * <Blog.Feed.LoadMore asChild>
- *   {({ hasNextPage, isLoading, loadNextPage }) => (
- *     <button
- *       onClick={loadNextPage}
- *       disabled={!hasNextPage || isLoading}
- *     >
- *       {isLoading ? 'Loading...' : 'Load More'}
- *     </button>
- *   )}
+ * <Blog.Feed.LoadMore>
+ *   <button>Load More</button>
  * </Blog.Feed.LoadMore>
  * ```
  */
-export const LoadMore = React.forwardRef<HTMLElement, LoadMoreProps>((props, ref) => {
-  const { asChild, children, className, loadingState } = props;
+export const LoadMore = React.forwardRef<HTMLButtonElement, LoadMoreProps>(
+  (props, ref) => {
+    const { children, className, loadingState } = props;
 
-  return (
-    <CoreFeed.LoadMore>
-      {({ hasNextPage, isLoading, loadNextPage }) => {
-        if (!hasNextPage) return null;
-
-        const attributes: React.ButtonHTMLAttributes<HTMLButtonElement> & {
-          'data-testid'?: string;
-          'data-loading'?: boolean;
-          'data-has-next-page'?: boolean;
-        } = {
-          'data-testid': TestIds.blogFeedLoadMore,
-          'data-loading': isLoading,
-          'data-has-next-page': hasNextPage,
-          onClick: loadNextPage,
-        };
-
-        return (
-          <AsChildSlot
-            ref={ref}
-            asChild={asChild}
-            className={className}
-            {...attributes}
-            customElement={children}
-            customElementProps={{ isLoading, loadNextPage }}
-            content={isLoading && loadingState ? loadingState : undefined}
-          >
-            <button>{isValidChildren(children) ? children : null}</button>
-          </AsChildSlot>
-        );
-      }}
-    </CoreFeed.LoadMore>
-  );
-});
+    return (
+      <GenericList.Actions.LoadMore
+        ref={ref}
+        className={className}
+        loadingState={loadingState}
+        data-testid={TestIds.blogFeedLoadMore}
+      >
+        {children}
+      </GenericList.Actions.LoadMore>
+    );
+  },
+);
 
 LoadMore.displayName = 'Blog.Feed.LoadMore';

--- a/packages/headless-components/blog/src/react/Feed.tsx
+++ b/packages/headless-components/blog/src/react/Feed.tsx
@@ -1,8 +1,8 @@
 import {
-  Sort as SortPrimitive,
   GenericList,
-  type ListVariant,
+  Sort as SortPrimitive,
   type GenericListRepeaterRenderProps,
+  type ListVariant,
 } from '@wix/headless-components/react';
 import { AsChildChildren, AsChildSlot } from '@wix/headless-utils/react';
 import { createServicesMap } from '@wix/services-manager';
@@ -180,8 +180,7 @@ export const PostItems = React.forwardRef<HTMLElement, PostItemsProps>((props, r
 
 PostItems.displayName = 'Blog.Feed.PostItems';
 
-export type PostRepeaterRenderProps =
-  GenericListRepeaterRenderProps<PostWithResolvedFields>;
+export type PostRepeaterRenderProps = GenericListRepeaterRenderProps<PostWithResolvedFields>;
 
 export interface SortProps {
   /**
@@ -325,24 +324,30 @@ export interface PostItemRepeaterProps {
  *   <Blog.Post.PublishDate />
  * </Blog.Feed.PostItemRepeater>
  *
- * // With offset/limit
- * <Blog.Feed.PostItemRepeater offset={0} limit={10}>
- *   <Blog.Post.Title />
- * </Blog.Feed.PostItemRepeater>
- *
- * // AsChild usage with custom wrapper
+ * // AsChild usage with custom wrapper and conditional rendering
  * <Blog.Feed.PostItemRepeater asChild>
- *   {({ items, variant, itemWrapper }) => (
- *     <CustomWrapper
- *       items={items}
- *       variant={variant}
- *       itemRenderer={(item, index) =>
- *         itemWrapper({ item, index, children: <>
- *           <Blog.Post.Title />
- *           <Blog.Post.Excerpt />
- *         </> })
- *       }
- *     />
+ *   {({ itemWrapper, items }) => (
+ *     <>
+ *       {items.map((item, index) =>
+ *         itemWrapper({
+ *           item,
+ *           index,
+ *           children:
+ *             index === 0 ? (
+ *               <div className="featured">
+ *                 <Blog.Post.Title />
+ *                 <Blog.Post.Excerpt />
+ *                 <Blog.Post.PublishDate />
+ *               </div>
+ *             ) : (
+ *               <div>
+ *                 <Blog.Post.Title />
+ *                 <Blog.Post.Excerpt />
+ *               </div>
+ *             ),
+ *         })
+ *       )}
+ *     </>
  *   )}
  * </Blog.Feed.PostItemRepeater>
  * ```
@@ -352,20 +357,12 @@ export const PostItemRepeater = React.forwardRef<HTMLElement, PostItemRepeaterPr
     const { children, offset = 0, limit = Infinity, asChild } = props;
     const { fallbackImageUrl } = usePostsContext();
 
-    const itemWrapper: GenericList.GenericListRepeaterProps<PostWithResolvedFields>['itemWrapper'] = ({
-      item: post,
-      children,
-    }) => (
-      <Post.Root
-        key={post._id}
-        post={post}
-        asChild
-        fallbackImageUrl={fallbackImageUrl}
-      >
-        {children}
-      </Post.Root>
-    );
-
+    const itemWrapper: GenericList.GenericListRepeaterProps<PostWithResolvedFields>['itemWrapper'] =
+      ({ item: post, children }) => (
+        <Post.Root key={post._id} post={post} asChild fallbackImageUrl={fallbackImageUrl}>
+          {children}
+        </Post.Root>
+      );
 
     // If offset/limit are used, use asChild pattern to access items and slice them
     if (offset !== 0 || limit !== Infinity) {
@@ -425,21 +422,19 @@ export interface LoadMoreProps {
  * </Blog.Feed.LoadMore>
  * ```
  */
-export const LoadMore = React.forwardRef<HTMLButtonElement, LoadMoreProps>(
-  (props, ref) => {
-    const { children, className, loadingState } = props;
+export const LoadMore = React.forwardRef<HTMLButtonElement, LoadMoreProps>((props, ref) => {
+  const { children, className, loadingState } = props;
 
-    return (
-      <GenericList.Actions.LoadMore
-        ref={ref}
-        className={className}
-        loadingState={loadingState}
-        data-testid={TestIds.blogFeedLoadMore}
-      >
-        {children}
-      </GenericList.Actions.LoadMore>
-    );
-  },
-);
+  return (
+    <GenericList.Actions.LoadMore
+      ref={ref}
+      className={className}
+      loadingState={loadingState}
+      data-testid={TestIds.blogFeedLoadMore}
+    >
+      {children}
+    </GenericList.Actions.LoadMore>
+  );
+});
 
 LoadMore.displayName = 'Blog.Feed.LoadMore';


### PR DESCRIPTION
Initial integration with GenericList.Feed. Some findings:

1. `GenericList.Items` accepts a `className` prop, but it won't do anything since it doesn't render a wrapping element (acts like a React.Fragment). Needed to wrap children with a div.
2. PostItemRepeater supported `offset`/`limit` props, which allowed a pattern to modify what DOM element is rendered by slicing the array. GenericList doesn't support them, via `asChild`.
3. `data-variant` props weren't used in shadcn components due to (2/want to switch variant for 1st item, use another variant for others)